### PR TITLE
fix: タスクIDの重複問題を修正

### DIFF
--- a/src/todo.py
+++ b/src/todo.py
@@ -16,13 +16,22 @@ class Todo:
         Returns:
             int: 追加されたタスクのID
         """
+        # 既存のタスクから最大IDを取得
+        max_id = 0
+        for task in self.tasks:
+            if task['id'] > max_id:
+                max_id = task['id']
+        
+        # 新しいIDは最大ID + 1
+        new_id = max_id + 1
+        
         task = {
-            'id': len(self.tasks) + 1,
+            'id': new_id,
             'title': title,
             'description': description,
             'priority': priority,
             'completed': False,
-            'created_at': '2025-07-16'  # 簡易版（実際はdatetime.now()を使う）
+            'created_at': '2025-07-17'  # 簡易版（実際はdatetime.now()を使う）
         }
         self.tasks.append(task)
         return task['id']


### PR DESCRIPTION
   ## 修正内容
   - 削除後のタスクIDが重複する問題を解決
   - 最大ID + 1の方式でID生成を改善
   - 作成日時を更新

   ## 問題の詳細
   - タスクを削除した後、新しいタスクのIDが重複していた
   - `len(self.tasks) + 1`の方式では削除済みIDを考慮していなかった

   ## 修正方法
   - 既存タスクの最大IDを計算
   - 新しいID = 最大ID + 1
   - 削除済みIDの重複を防止

   ## テスト結果
   - タスク追加→削除→追加のテストを実行
   - ID重複が解消されることを確認

   ## 関連Issue
   - なし（バグ修正）